### PR TITLE
Fix typo in divider register name

### DIFF
--- a/src/gameboycore/include/gameboycore/memorymap.h
+++ b/src/gameboycore/include/gameboycore/memorymap.h
@@ -85,7 +85,7 @@ namespace gb{
             SC_REGISTER = 0xFF02,
 
             DIVIDER_LO_REGISTER = 0xFF03,
-            DIVIDER_REGISER     = 0xFF04,
+            DIVIDER_REGISTER     = 0xFF04,
 
             TIMER_COUNTER_REGISTER    = 0xFF05,
             TIMER_MODULO_REGISTER     = 0xFF06,

--- a/src/gameboycore/src/mmu.cpp
+++ b/src/gameboycore/src/mmu.cpp
@@ -109,7 +109,7 @@ namespace gb
             {
                 mbc_->write(value | 0x0F, addr);
             }
-            else if (addr == memorymap::DIVIDER_REGISER)
+            else if (addr == memorymap::DIVIDER_REGISTER)
             {
                 mbc_->write(0, addr);
             }

--- a/src/gameboycore/src/timer.cpp
+++ b/src/gameboycore/src/timer.cpp
@@ -6,7 +6,7 @@ namespace gb
         controller_(mmu.get(memorymap::TIMER_CONTROLLER_REGISTER)),
         counter_(mmu.get(memorymap::TIMER_COUNTER_REGISTER)),
         modulo_(mmu.get(memorymap::TIMER_MODULO_REGISTER)),
-        divider_(mmu.get(memorymap::DIVIDER_REGISER)),
+        divider_(mmu.get(memorymap::DIVIDER_REGISTER)),
         t_clock_(0),
         base_clock_(0),
         div_clock_(0),


### PR DESCRIPTION
## Summary
- Correct `DIVIDER_REGISER` typo to `DIVIDER_REGISTER`
- Update MMU and timer references to use the corrected constant

## Testing
- `cmake ..`
- `cmake --build . --target gameboycore`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_688e486ad51c832287b2f11ae25a68e0