### PR TITLE
Fix DIV reset for accurate timer

### DIFF
--- a/src/gameboycore/include/gameboycore/timer.h
+++ b/src/gameboycore/include/gameboycore/timer.h
@@ -29,6 +29,7 @@ namespace gb
 
     private:
         void tick();
+        void reset();
 
         uint8_t& controller_; // TAC
         uint8_t& counter_;    // TIMA

--- a/src/gameboycore/src/mmu.cpp
+++ b/src/gameboycore/src/mmu.cpp
@@ -112,6 +112,10 @@ namespace gb
             else if (addr == memorymap::DIVIDER_REGISER)
             {
                 mbc_->write(0, addr);
+                if (write_handlers_[addr - 0xFF00])
+                {
+                    write_handlers_[addr - 0xFF00](value, addr);
+                }
             }
             else
             {

--- a/src/gameboycore/src/timer.cpp
+++ b/src/gameboycore/src/timer.cpp
@@ -12,6 +12,7 @@ namespace gb
         div_clock_(0),
         timer_interrupt_(mmu, InterruptProvider::Interrupt::TIMER)
     {
+        mmu.addWriteHandler(memorymap::DIVIDER_REGISER, [this](uint8_t, uint16_t) { reset(); });
     }
 
     void Timer::update(const uint8_t machine_cycles)
@@ -69,6 +70,14 @@ namespace gb
                 }
             }
         }
+    }
+
+    void Timer::reset()
+    {
+        divider_ = 0;
+        t_clock_ = 0;
+        base_clock_ = 0;
+        div_clock_ = 0;
     }
 
     Timer::~Timer()

--- a/src/gameboycore/src/timer.cpp
+++ b/src/gameboycore/src/timer.cpp
@@ -12,7 +12,7 @@ namespace gb
         div_clock_(0),
         timer_interrupt_(mmu, InterruptProvider::Interrupt::TIMER)
     {
-        mmu.addWriteHandler(memorymap::DIVIDER_REGISER, [this](uint8_t, uint16_t) { reset(); });
+        mmu.addWriteHandler(memorymap::DIVIDER_REGISTER, [this](uint8_t, uint16_t) { reset(); });
     }
 
     void Timer::update(const uint8_t machine_cycles)


### PR DESCRIPTION
## Summary
- reset internal timer counters when writing to DIV register
- invoke DIV write handler in MMU to allow timer to reset

## Testing
- `./src/gameboycore/tests/gameboy_tests`

------
https://chatgpt.com/codex/tasks/task_e_688e483f0284832286326c07d4258e2a